### PR TITLE
Update README.md more configuration information

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please note that `GetLinearVelocity()` returns an estimation of the instantaneou
 
 ## Build and Run
 
-To use this module, follow these instructions to [add a module from the Viam Registry](https://docs.viam.com/registry/configure/#add-a-modular-resource-from-the-viam-registry) and select the `viam:visual_odometry:opencv_orb` model from the [`monocular-visual-odometry` module](https://app.viam.com/module/viam/agilex-limo).
+To use this module, follow these instructions to [add a module from the Viam Registry](https://docs.viam.com/registry/configure/#add-a-modular-resource-from-the-viam-registry) and select the `viam:visual_odometry:opencv_orb` model from the [`monocular-visual-odometry` module](https://app.viam.com/module/viam/monocular-visual-odometry).
 
 ## Configure your Monocular Visual Odometry Movement Sensor
 


### PR DESCRIPTION
We're trying to reduce duplication across docs and modules and are therefore moving configuration information to the repo that contains the module. The docs already point to the module's readme and so does the registry, so this move should make the flow for users easier.